### PR TITLE
Handle tokens with invalid decimal places better

### DIFF
--- a/apps/web/src/libs/token-batcher.ts
+++ b/apps/web/src/libs/token-batcher.ts
@@ -44,11 +44,16 @@ function parseTokenMetadata(metadata: string | undefined): { decimalPlaces: numb
 			'decimalPlaces' in parsedMetadata
 		) {
 			decimalPlaces = Number(parsedMetadata.decimalPlaces ?? 0);
-			if (Number.isNaN(decimalPlaces) || decimalPlaces < 0) {
-				decimalPlaces = 0;
-			}
 		}
 	} catch {  /* Ignore  */ }
+
+	if (!Number.isInteger(decimalPlaces)) {
+		decimalPlaces = Math.floor(decimalPlaces);
+	}
+
+	if (!Number.isFinite(decimalPlaces) || decimalPlaces < 0 || decimalPlaces > 1024) {
+		decimalPlaces = 0;
+	}
 
 	return({ decimalPlaces });
 }

--- a/apps/web/src/libs/token-batcher.ts
+++ b/apps/web/src/libs/token-batcher.ts
@@ -31,8 +31,9 @@ interface WaiterPromise {
  * Parsers
  */
 function parseTokenMetadata(metadata: string | undefined): { decimalPlaces: number } {
+	let decimalPlaces = 0;
 	if (!metadata) {
-		return({ decimalPlaces: 0 });
+		return({ decimalPlaces });
 	}
 
 	try {
@@ -42,13 +43,14 @@ function parseTokenMetadata(metadata: string | undefined): { decimalPlaces: numb
 			typeof parsedMetadata === 'object' &&
 			'decimalPlaces' in parsedMetadata
 		) {
-			return({
-				decimalPlaces: Number(parsedMetadata.decimalPlaces ?? 0)
-			});
+			decimalPlaces = Number(parsedMetadata.decimalPlaces ?? 0);
+			if (Number.isNaN(decimalPlaces) || decimalPlaces < 0) {
+				decimalPlaces = 0;
+			}
 		}
 	} catch {  /* Ignore  */ }
 
-	return({ decimalPlaces: 0 });
+	return({ decimalPlaces });
 }
 
  export function parseTokenDetails(token: AccountInfo, baseToken: GenericAccount): TokenDetails {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
 	"name": "explorer",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
@@ -16,7 +16,7 @@
 				"node": ">=20.18.0",
 				"npm": ">=9.8.1"
 			},
-			"version": "0.1.1"
+			"version": "0.1.2"
 		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.25.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "explorer",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "",
 	"author": "Keeta Token Genesis LLC",
 	"private": true,


### PR DESCRIPTION
## Description
This fixes an issue with the explorer handling of `decimalPlaces` which are not a number, and just converts them silently to 0.